### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -31,7 +31,7 @@
   <classpathentry kind="var" path="M2_REPO/org/mockito/mockito-all/1.8.4/mockito-all-1.8.4.jar" sourcepath="M2_REPO/org/mockito/mockito-all/1.8.4/mockito-all-1.8.4-sources.jar"/>
   <classpathentry kind="var" path="M2_REPO/org/apache/mina/mina-core/2.0.7/mina-core-2.0.7.jar" sourcepath="M2_REPO/org/apache/mina/mina-core/2.0.7/mina-core-2.0.7-sources.jar"/>
   <classpathentry kind="var" path="M2_REPO/org/slf4j/slf4j-simple/1.6.2/slf4j-simple-1.6.2.jar" sourcepath="M2_REPO/org/slf4j/slf4j-simple/1.6.2/slf4j-simple-1.6.2-sources.jar"/>
-  <classpathentry kind="var" path="M2_REPO/commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.jar" sourcepath="M2_REPO/commons-collections/commons-collections/3.2.1/commons-collections-3.2.1-sources.jar"/>
+  <classpathentry kind="var" path="M2_REPO/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2.jar" sourcepath="M2_REPO/commons-collections/commons-collections/3.2.2/commons-collections-3.2.2-sources.jar"/>
   <classpathentry kind="var" path="M2_REPO/com/h2database/h2/1.3.174/h2-1.3.174.jar" sourcepath="M2_REPO/com/h2database/h2/1.3.174/h2-1.3.174-sources.jar"/>
   <classpathentry kind="var" path="M2_REPO/org/apache/wicket/wicket-extensions/6.12.0/wicket-extensions-6.12.0.jar" sourcepath="M2_REPO/org/apache/wicket/wicket-extensions/6.12.0/wicket-extensions-6.12.0-sources.jar"/>
   <classpathentry kind="var" path="M2_REPO/org/apache/wicket/wicket-datetime/6.12.0/wicket-datetime-6.12.0.jar" sourcepath="M2_REPO/org/apache/wicket/wicket-datetime/6.12.0/wicket-datetime-6.12.0-sources.jar"/>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
 		<dependency>
 			<groupId>commons-collections</groupId>
 			<artifactId>commons-collections</artifactId>
-			<version>3.2.1</version>
+			<version>3.2.2</version>
 		</dependency>
 		<dependency>
 			<groupId>com.h2database</groupId>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
